### PR TITLE
Update product names and add Windows 11 25H2

### DIFF
--- a/data/products.json
+++ b/data/products.json
@@ -7,15 +7,16 @@
   "2378": "Windows 10 22H2 Home China (Build 19045.2006)",
   "2616": "Windows 11 22H2 v2 (Build 22621.1702)",
   "2617": "Windows 11 22H2 v2 Home China (Build 22621.1702)",
-  "2618": "Windows 10 22H2 v1 (Build 19045.2965) ❤️",
+  "2618": "❤️ Windows 10 22H2 v1 (Build 19045.2965)",
   "2860": "Windows 11 23H2 v1 (Build 22631.2428)",
   "2861": "Windows 11 23H2 v1 Home China (Build 22631.2428)",
   "2935": "Windows 11 23H2 v2 (Build 22631.2861)",
   "2936": "Windows 11 23H2 v2 Home China (Build 22631.2861)",
-  "3113": "Windows 11 24H2 ❤️ (Build 26100.1742)",
+  "3113": "Windows 11 24H2 (Build 26100.1742)",
   "3114": "Windows 11 24H2 Home China (Build 26100.1742)",
   "3115": "Windows 11 24H2 Pro China (Build 26100.1742)",
   "3131": "Windows 11 Arm64 24H2 (26100.1742)",
   "3132": "Windows 11 Arm64 24H2 Home China (26100.1742)",
-  "3133": "Windows 11 Arm64 24H2 Pro China (26100.1742)"
+  "3133": "Windows 11 Arm64 24H2 Pro China (26100.1742)",
+  "3262": "❤️ Windows 11 25H2 (26200.6584)"
 }


### PR DESCRIPTION
Moved heart emoji in product 2618, removed it from 3113, and added new product 3262 for Windows 11 25H2 with a heart emoji.