### PR TITLE
Update Windows 11 button to 25H2 release

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
             📌
             <button onClick="setSearch('Windows 8\\.1');">Windows 8.1</button>
             <button onClick="setSearch('Windows 10 22H2');">Latest Windows 10</button>
-            <button onClick="setSearch('24H2');">Latest Windows 11</button>
+            <button onClick="setSearch('25H2');">Latest Windows 11</button>
         </div>
         <table style="table-layout: auto;">
             <thead>


### PR DESCRIPTION
Changed the quick search button label and value from '24H2' to '25H2' to reflect the latest Windows 11 release.