### PR TITLE
Add Windows 11 25H2 Home China to products

### DIFF
--- a/data/products.json
+++ b/data/products.json
@@ -18,5 +18,6 @@
   "3131": "Windows 11 Arm64 24H2 (26100.1742)",
   "3132": "Windows 11 Arm64 24H2 Home China (26100.1742)",
   "3133": "Windows 11 Arm64 24H2 Pro China (26100.1742)",
-  "3262": "❤️ Windows 11 25H2 (26200.6584)"
+  "3262": "❤️ Windows 11 25H2 (26200.6584)",
+  "3263": "Windows 11 25H2 Home China (26200.6584)"
 }


### PR DESCRIPTION
Added entry for Windows 11 25H2 Home China (26200.6584) to products.json to support the new product variant.