### PR TITLE
Add Windows 11 25H2 Pro China to products list

### DIFF
--- a/data/products.json
+++ b/data/products.json
@@ -19,5 +19,6 @@
   "3132": "Windows 11 Arm64 24H2 Home China (26100.1742)",
   "3133": "Windows 11 Arm64 24H2 Pro China (26100.1742)",
   "3262": "❤️ Windows 11 25H2 (26200.6584)",
-  "3263": "Windows 11 25H2 Home China (26200.6584)"
+  "3263": "Windows 11 25H2 Home China (26200.6584)",
+  "3264": "Windows 11 25H2 Pro China (26200.6584)"
 }


### PR DESCRIPTION
Added entry for Windows 11 25H2 Pro China (26200.6584) to products.json to keep product catalog up to date.