### PR TITLE
Add Windows 11 Arm64 25H2 to products list

### DIFF
--- a/data/products.json
+++ b/data/products.json
@@ -20,5 +20,6 @@
   "3133": "Windows 11 Arm64 24H2 Pro China (26100.1742)",
   "3262": "❤️ Windows 11 25H2 (26200.6584)",
   "3263": "Windows 11 25H2 Home China (26200.6584)",
-  "3264": "Windows 11 25H2 Pro China (26200.6584)"
+  "3264": "Windows 11 25H2 Pro China (26200.6584)",
+  "3265": "Windows 11 Arm64 25H2 (26200.6584)"
 }


### PR DESCRIPTION
Added product entry 'Windows 11 Arm64 25H2 (26200.6584)' with ID 3265 to data/products.json.