### PR TITLE
Add Windows 11 Arm64 Home China 25H2 to products

### DIFF
--- a/data/products.json
+++ b/data/products.json
@@ -21,5 +21,6 @@
   "3262": "❤️ Windows 11 25H2 (26200.6584)",
   "3263": "Windows 11 25H2 Home China (26200.6584)",
   "3264": "Windows 11 25H2 Pro China (26200.6584)",
-  "3265": "Windows 11 Arm64 25H2 (26200.6584)"
+  "3265": "Windows 11 Arm64 25H2 (26200.6584)",
+  "3266": "Windows 11 Arm64 25H2 Home China (26200.6584)"
 }


### PR DESCRIPTION
Added product entry 3266 for Windows 11 Arm64 25H2 Home China (26200.6584) in products.json.